### PR TITLE
Update Hardware.pm to get UUID on global zones

### DIFF
--- a/lib/GLPI/Agent/Task/Inventory/Solaris/Hardware.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Solaris/Hardware.pm
@@ -50,12 +50,30 @@ sub doInventory {
                 command => '/usr/sbin/zoneadm -z global list -p',
                 logger  => $logger
             );
+            if ($hardware->{UUID} eq '') {
+                $hardware->{UUID} = _getUUIDGlobal( logger  => $logger );
+            }
         }
     } elsif ($arch eq 'sparc') {
         $hardware->{UUID} = _getUUID( logger  => $logger );
     }
 
     $inventory->setHardware($hardware);
+}
+
+sub _getUUIDGlobal {
+    my (%params) = (
+        command => 'virtinfo -u',
+        @_
+    );
+
+    my $line = getFirstLine(%params);
+    return unless $line;
+
+    my @info = split(/: /, $line);
+    my $uuid = $info[1];
+
+    return $uuid;
 }
 
 sub _getUUID {

--- a/lib/GLPI/Agent/Task/Inventory/Solaris/Hardware.pm
+++ b/lib/GLPI/Agent/Task/Inventory/Solaris/Hardware.pm
@@ -50,7 +50,7 @@ sub doInventory {
                 command => '/usr/sbin/zoneadm -z global list -p',
                 logger  => $logger
             );
-            if ($hardware->{UUID} eq '') {
+            if (empty($hardware->{UUID})) {
                 $hardware->{UUID} = _getUUIDGlobal( logger  => $logger );
             }
         }

--- a/resources/solaris/virtinfo/sample1
+++ b/resources/solaris/virtinfo/sample1
@@ -1,0 +1,1 @@
+Domain UUID: 915fbcf6-2b64-48ba-9b7b-05df341428be

--- a/resources/solaris/virtinfo/sample1
+++ b/resources/solaris/virtinfo/sample1
@@ -1,1 +1,0 @@
-Domain UUID: 915fbcf6-2b64-48ba-9b7b-05df341428be

--- a/resources/solaris/virtinfo/solaris
+++ b/resources/solaris/virtinfo/solaris
@@ -1,0 +1,1 @@
+Domain UUID: 915fbcf6-2b64-48ba-9b7b-05df341428be

--- a/t/tasks/inventory/solaris/hardware.t
+++ b/t/tasks/inventory/solaris/hardware.t
@@ -11,9 +11,7 @@ use GLPI::Agent::Tools::Solaris;
 use GLPI::Agent::Task::Inventory::Solaris::Hardware;
 
 my %virtinfo_tests = (
-    'sample1' => {
-        'Domain UUID' => '915fbcf6-2b64-48ba-9b7b-05df341428be',
-    },
+    'sample1' => '915fbcf6-2b64-48ba-9b7b-05df341428be',
 );
 
 plan tests => 1;

--- a/t/tasks/inventory/solaris/hardware.t
+++ b/t/tasks/inventory/solaris/hardware.t
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::Deep;
+use Test::More;
+use Test::NoWarnings;
+
+use GLPI::Agent::Tools::Solaris;
+use GLPI::Agent::Task::Inventory::Solaris::Hardware;
+
+my %virtinfo_tests = (
+    'sample1' => {
+        'Domain UUID' => '915fbcf6-2b64-48ba-9b7b-05df341428be',
+    },
+);
+
+foreach my $test (keys %virtinfo_tests) {
+    my $file   = "resources/solaris/virtinfo/$test";
+    my $result = GLPI::Agent::Task::Inventory::Solaris::Hardware::_getUUIDGlobal(file => $file);
+    cmp_deeply($result, $virtinfo_tests{$test}, "virtinfo parsing: $test");
+}

--- a/t/tasks/inventory/solaris/hardware.t
+++ b/t/tasks/inventory/solaris/hardware.t
@@ -11,13 +11,13 @@ use GLPI::Agent::Tools::Solaris;
 use GLPI::Agent::Task::Inventory::Solaris::Hardware;
 
 my %virtinfo_tests = (
-    'sample1' => '915fbcf6-2b64-48ba-9b7b-05df341428be',
+    'solaris' => '915fbcf6-2b64-48ba-9b7b-05df341428be',
 );
 
-plan tests => 1;
+plan tests => (scalar keys %virtinfo_tests) + 1;
 
 foreach my $test (keys %virtinfo_tests) {
     my $file   = "resources/solaris/virtinfo/$test";
     my $result = GLPI::Agent::Task::Inventory::Solaris::Hardware::_getUUIDGlobal(file => $file);virtinfo_tests
-    cmp_deeply($result, $virtinfo_tests{$test}, "virtinfo parsing: $test");
+    is($result, $virtinfo_tests{$test}, "virtinfo parsing: $test");
 }

--- a/t/tasks/inventory/solaris/hardware.t
+++ b/t/tasks/inventory/solaris/hardware.t
@@ -16,6 +16,8 @@ my %virtinfo_tests = (
     },
 );
 
+plan tests => (scalar keys %virtinfo_tests) + 1;
+
 foreach my $test (keys %virtinfo_tests) {
     my $file   = "resources/solaris/virtinfo/$test";
     my $result = GLPI::Agent::Task::Inventory::Solaris::Hardware::_getUUIDGlobal(file => $file);

--- a/t/tasks/inventory/solaris/hardware.t
+++ b/t/tasks/inventory/solaris/hardware.t
@@ -16,10 +16,10 @@ my %virtinfo_tests = (
     },
 );
 
-plan tests => (scalar keys %virtinfo_tests) + 1;
+plan tests => 1;
 
 foreach my $test (keys %virtinfo_tests) {
     my $file   = "resources/solaris/virtinfo/$test";
-    my $result = GLPI::Agent::Task::Inventory::Solaris::Hardware::_getUUIDGlobal(file => $file);
+    my $result = GLPI::Agent::Task::Inventory::Solaris::Hardware::_getUUIDGlobal(file => $file);virtinfo_tests
     cmp_deeply($result, $virtinfo_tests{$test}, "virtinfo parsing: $test");
 }


### PR DESCRIPTION
On modern Solaris servers, multiple LDOMs can be created linked to the same hardware, so the serial number is the same on all of them.
On my systems, GLPI got confused when updating inventory because multiple systems had the same serial number but none of them had a UUID.

GLPI agent remote inventory tries to get the UUID of the global zones using the command '/usr/sbin/zoneadm -z global list -p', but this returns an empty string when checked on the global zone.

I added an additional check for the global zone in sparc, to get a unique UUID from the command 'virtinfo -u'.